### PR TITLE
Make bats-run-current-test work with current bats-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,3 @@ Keybinding: <kbd>C-c C-,</kbd>
 Run bats with the current test at point.
 
 Keybinding: <kbd>C-c M-,</kbd>
-
-Note, this feature is not yet merged into a Bats release.
-See the [github issue](https://github.com/sstephenson/bats/issues/36) for more info.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Synopsis
 
-`bats-mode` is an Emacs mode for editing and running [Bats tests](https://github.com/sstephenson/bats).
+`bats-mode` is an Emacs mode for editing and running [Bats tests](https://github.com/bats-core/bats-core).
 
 `bats-mode` derives from the bash flavor of `sh-mode`, adding font-lock for bats keywords.
 

--- a/bats-mode.el
+++ b/bats-mode.el
@@ -79,9 +79,10 @@ See URL `https://github.com/sstephenson/bats'.
 (defun bats-run (file &optional name)
   "Run bats -t FILE.
 NAME if given is used as the bats test pattern."
-  (let ((cmd (concat bats-program " -t " file)))
-    (compile (if name (concat (format "BATS_TEST_PATTERN='^%s$' " name) cmd)
-               cmd))))
+  (let ((cmd (concat bats-program
+                     (when name (format " -f '^%s$'" name))
+                     " -t " file)))
+    (compile cmd)))
 
 (defun bats-run-current-test ()
   "Run bats with the current test at point."


### PR DESCRIPTION
Previously, bats-run-current-test relied on unmerged functionality. Now, the needed feature is is bats-core, but works differently. Instead of passing an environment variable `BATS_TEST_PATTERN`, we specify the test to run with `-f` command line switch.
